### PR TITLE
Adaptions needed for using Photonic3D on the YHD-101 

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -291,7 +291,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #define Y_HOME_DIR -1
 #define Z_HOME_DIR -1
 
-#define min_software_endstops false //--BH If true, axis won't move to coordinates less than HOME_POS.
+#define min_software_endstops true //--BR If true, axis won't move to coordinates less than HOME_POS.
 #define max_software_endstops true  // If true, axis won't move to coordinates greater than the defined lengths below.
 
 //============================= Bed Auto Leveling ===========================

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -361,10 +361,10 @@ const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 
 #define DEFAULT_AXIS_STEPS_PER_UNIT   {80, 80, 1600, 700}  //--BH default settings for for KLD-LCD1260/2150
 #define DEFAULT_MAX_FEEDRATE          {400, 400, 10, 45}   //--BR limit z-axis moves to 10 mm/sec.
-#define DEFAULT_MAX_ACCELERATION      {1000, 1000, 400, 1000}  //--BH X, Y, Z, E maximum start speed for accelerated moves. E default values are good for skeinforge 40+, for older versions raise them a lot.
+#define DEFAULT_MAX_ACCELERATION      {1000, 1000, 50, 1000}  //--Br X, Y, Z, E maximum start speed for accelerated moves. E default values are good for skeinforge 40+, for older versions raise them a lot.
 
-#define DEFAULT_ACCELERATION          1000    //--BH X, Y, Z and E max acceleration in mm/s^2 for printing moves
-#define DEFAULT_RETRACT_ACCELERATION  2000   //--BH X, Y, Z and E max acceleration in mm/s^2 for retracts
+#define DEFAULT_ACCELERATION          50   //--BR X, Y, Z and E max acceleration in mm/s^2 for printing moves
+#define DEFAULT_RETRACT_ACCELERATION  50   //--BR X, Y, Z and E max acceleration in mm/s^2 for retracts
 
 // Offset of the extruders (uncomment if using more than one and relying on firmware to position when changing).
 // The offset has to be X=0, Y=0 for the extruder 0 hotend (default extruder).

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -360,7 +360,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 // default settings
 
 #define DEFAULT_AXIS_STEPS_PER_UNIT   {80, 80, 1600, 700}  //--BH default settings for for KLD-LCD1260/2150
-#define DEFAULT_MAX_FEEDRATE          {400, 400, 200, 45}  //--BH (mm/sec)
+#define DEFAULT_MAX_FEEDRATE          {400, 400, 10, 45}   //--BR limit z-axis moves to 10 mm/sec.
 #define DEFAULT_MAX_ACCELERATION      {1000, 1000, 400, 1000}  //--BH X, Y, Z, E maximum start speed for accelerated moves. E default values are good for skeinforge 40+, for older versions raise them a lot.
 
 #define DEFAULT_ACCELERATION          1000    //--BH X, Y, Z and E max acceleration in mm/s^2 for printing moves

--- a/README.md
+++ b/README.md
@@ -1,157 +1,10 @@
 Printer Information
 ===================
-Modified for use on the KLD series of printers, should work on the 1260 and 2150 as well as clones. No guarantee that it will work on any other printers. It will not work as is on the Wanhao Duplicator 7.
+Fork from WheresWaldo/Marlin_KLD-LCD where limiting machine definitions are adapted to the (late March 2017) YHD-101 using Photonic3D which tries to move the build plate faster than the hardware accepts.
 
-All of the direct DLP control for the mUVeDLP printers will not be pertinent to these printers so all the added M65x commands have been purged from the source code.
+No guarantee that it will work on any other printer though these changes should work on anything that accepts WheresWaldo's Marlin_KLD-LCD.
 
--Marlin Firmware-
-Marlin has a GPL license because I believe in open development.
-Please do not use this code in products (3D printers, CNC etc) that are closed source or are crippled by a patent.
-
-Quick Information
-===================
-This RepRap firmware is a mashup between <a href="https://github.com/kliment/Sprinter">Sprinter</a>, <a href="https://github.com/simen/grbl/tree">grbl</a> and many original parts.
-
-
-The normal default baudrate is 250000. This baudrate has less jitter and hence errors than the usual 115200 baud, but is less supported by drivers and host-environments.
-Since nanoDLP does not support 250000, 115200 is used as the default instead.
-
-Differences and additions to the already good Sprinter firmware:
-================================================================
-
-*Look-ahead:*
-
-Marlin has look-ahead. While sprinter has to break and re-accelerate at each corner,
-lookahead will only decelerate and accelerate to a velocity,
-so that the change in vectorial velocity magnitude is less than the xy_jerk_velocity.
-This is only possible, if some future moves are already processed, hence the name.
-It leads to less over-deposition at corners, especially at flat angles.
-
-*EEPROM:*
-
-If you know your PID values, the acceleration and max-velocities of your unique machine, you can set them, and finally store them in the EEPROM.
-After each reboot, it will magically load them from EEPROM, independent what your Configuration.h says.
-
-*LCD Menu:*
-
-If your hardware supports it, you can build yourself a LCD-CardReader+Click+encoder combination. It will enable you to realtime tune temperatures,
-accelerations, velocities, flow rates, select and print files from the SD card, preheat, disable the steppers, and do other fancy stuff.
-One working hardware is documented here: http://www.thingiverse.com/thing:12663
-Also, with just a 20x4 or 16x2 display, useful data is shown.
-
-*SD card folders:*
-
-If you have an SD card reader attached to your controller, also folders work now. Listing the files in pronterface will show "/path/subpath/file.g".
-You can write to file in a subfolder by specifying a similar text using small letters in the path.
-Also, backup copies of various operating systems are hidden, as well as files not ending with ".g".
-
-*SD card folders:*
-
-If you place a file auto[0-9].g into the root of the sd card, it will be automatically executed if you boot the printer. The same file will be executed by selecting "Autostart" from the menu.
-First *0 will be performed, than *1 and so on. That way, you can heat up or even print automatically without user interaction.
-
-*Endstop trigger reporting:*
-
-If an endstop is hit while moving towards the endstop, the location at which the firmware thinks that the endstop was triggered is outputed on the serial port.
-This is useful, because the user gets a warning message.
-However, also tools like QTMarlin can use this for finding acceptable combinations of velocity+acceleration.
-
-Implemented G Codes:
-====================
-
-*  G0  -> G1
-*  G1  - Coordinated Movement X Y Z E
-*  G2  - CW ARC
-*  G3  - CCW ARC
-*  G4  - Dwell S<seconds> or P<milliseconds>
-*  G10 - retract filament according to settings of M207
-*  G11 - retract recover filament according to settings of M208
-*  G28 - Home all Axis
-*  G29 - Detailed Z-Probe, probes the bed at 3 points.  You must de at the home position for this to work correctly.
-*  G30 - Single Z Probe, probes bed at current XY location.
-*  G90 - Use Absolute Coordinates
-*  G91 - Use Relative Coordinates
-*  G92 - Set current position to cordinates given
-
-M Codes
-*  M0   - Unconditional stop - Wait for user to press a button on the LCD (Only if ULTRA_LCD is enabled)
-*  M1   - Same as M0
-*  M17  - Enable/Power all stepper motors
-*  M18  - Disable all stepper motors; same as M84
-*  M20  - List SD card
-*  M21  - Init SD card
-*  M22  - Release SD card
-*  M23  - Select SD file (M23 filename.g)
-*  M24  - Start/resume SD print
-*  M25  - Pause SD print
-*  M26  - Set SD position in bytes (M26 S12345)
-*  M27  - Report SD print status
-*  M28  - Start SD write (M28 filename.g)
-*  M29  - Stop SD write
-*  M30  - Delete file from SD (M30 filename.g)
-*  M31  - Output time since last M109 or SD card start to serial
-*  M32  - Select file and start SD print (Can be used when printing from SD card)
-*  M42  - Change pin status via gcode Use M42 Px Sy to set pin x to value y, when omitting Px the onboard led will be used.
-*  M80  - Turn on Power Supply
-*  M81  - Turn off Power Supply
-*  M82  - Set E codes absolute (default)
-*  M83  - Set E codes relative while in Absolute Coordinates (G90) mode
-*  M84  - Disable steppers until next move, or use S<seconds> to specify an inactivity timeout, after which the steppers will be disabled.  S0 to disable the timeout.
-*  M85  - Set inactivity shutdown timer with parameter S<seconds>. To disable set zero (default)
-*  M92  - Set axis_steps_per_unit - same syntax as G92
-*  M104 - Set extruder target temp
-*  M105 - Read current temp
-*  M106 - Fan on
-*  M107 - Fan off
-*  M109 - Sxxx Wait for extruder current temp to reach target temp. Waits only when heating
-*         Rxxx Wait for extruder current temp to reach target temp. Waits when heating and cooling
-*  M114 - Output current position to serial port
-*  M115 - Capabilities string
-*  M117 - display message
-*  M119 - Output Endstop status to serial port
-*  M126 - Solenoid Air Valve Open (BariCUDA support by jmil)
-*  M127 - Solenoid Air Valve Closed (BariCUDA vent to atmospheric pressure by jmil)
-*  M128 - EtoP Open (BariCUDA EtoP = electricity to air pressure transducer by jmil)
-*  M129 - EtoP Closed (BariCUDA EtoP = electricity to air pressure transducer by jmil)
-*  M140 - Set bed target temp
-*  M190 - Sxxx Wait for bed current temp to reach target temp. Waits only when heating
-*         Rxxx Wait for bed current temp to reach target temp. Waits when heating and cooling
-*  M200 - Set filament diameter
-*  M201 - Set max acceleration in units/s^2 for print moves (M201 X1000 Y1000)
-*  M202 - Set max acceleration in units/s^2 for travel moves (M202 X1000 Y1000) Unused in Marlin!!
-*  M203 - Set maximum feedrate that your machine can sustain (M203 X200 Y200 Z300 E10000) in mm/sec
-*  M204 - Set default acceleration: S normal moves T filament only moves (M204 S3000 T7000) im mm/sec^2  also sets minimum segment time in ms (B20000) to prevent buffer underruns and M20 minimum feedrate
-*  M205 -  advanced settings:  minimum travel speed S=while printing T=travel only,  B=minimum segment time X= maximum xy jerk, Z=maximum Z jerk, E=maximum E jerk
-*  M206 - set additional homeing offset
-*  M207 - set retract length S[positive mm] F[feedrate mm/sec] Z[additional zlift/hop]
-*  M208 - set recover=unretract length S[positive mm surplus to the M207 S*] F[feedrate mm/sec]
-*  M209 - S<1=true/0=false> enable automatic retract detect if the slicer did not support G10/11: every normal extrude-only move will be classified as retract depending on the direction.
-*  M218 - set hotend offset (in mm): T<extruder_number> X<offset_on_X> Y<offset_on_Y>
-*  M220 S<factor in percent>- set speed factor override percentage
-*  M221 S<factor in percent>- set extrude factor override percentage
-*  M240 - Trigger a camera to take a photograph
-*  M280 - Position an RC Servo P<index> S<angle/microseconds>, ommit S to report back current angle
-*  M300 - Play beepsound S<frequency Hz> P<duration ms>
-*  M301 - Set PID parameters P I and D
-*  M302 - Allow cold extrudes
-*  M303 - PID relay autotune S<temperature> sets the target temperature. (default target temperature = 150C)
-*  M304 - Set bed PID parameters P I and D
-*  M400 - Finish all moves
-*  M401 - Lower z-probe if present
-*  M402 - Raise z-probe if present
-*  M500 - stores paramters in EEPROM
-*  M501 - reads parameters from EEPROM (if you need reset them after you changed them temporarily).
-*  M502 - reverts to the default "factory settings".  You still need to store them in EEPROM afterwards if you want to.
-*  M503 - print the current settings (from memory not from eeprom)
-*  M540 - Use S[0|1] to enable or disable the stop SD card print on endstop hit (requires ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
-*  M600 - Pause for filament change X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal]
-*  M907 - Set digital trimpot motor current using axis codes.
-*  M908 - Control digital trimpot directly.
-*  M350 - Set microstepping mode.
-*  M351 - Toggle MS1 MS2 pins directly.
-*  M928 - Start SD logging (M928 filename.g) - ended by M29
-*  M999 - Restart after being stopped by error
-
+For further information check the master https://github.com/WheresWaldo/Marlin_KLD-LCD
 
 Configuring and compilation:
 ============================
@@ -160,7 +13,7 @@ Install the arduino software IDE/toolset v1.6.8 or newer
    http://www.arduino.cc/en/Main/Software
 
 Copy the Marlin firmware
-   https://github.com/WheresWaldo/Marlin_KLD-LCD
+   https://github.com/bringho/Marlin_KLD-LCD
    (Use the download button)
 
 Start the arduino IDE.
@@ -172,5 +25,3 @@ Click the Verify/Compile button
 
 Click the Upload button
 If all goes well the firmware is uploading
-
-That's ok.  Enjoy Silky Smooth Printing.


### PR DESCRIPTION
These changes are proposed to stop the YHD-101 to stall the z-axis motor when Photonic3D tries to do fast manual moves and to increase safety as we should never have to manually move the build platform lower than the z endstop.
